### PR TITLE
[CLNP-8804] Bump js-yaml 4.3.0 -> 4.3.1 to fix quadratic-time !!omap DoS

### DIFF
--- a/discord-clone/package-lock.json
+++ b/discord-clone/package-lock.json
@@ -1873,9 +1873,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Lockfile-only remediation; package.json is unchanged since the fix is an in-range transitive bump (cosmiconfig requires js-yaml ^4.1.0):

- js-yaml  4.3.0 -> 4.3.1  High  GHSA-5p4m-2wfm-xmqj / CVE-2026-59870 Quadratic CPU consumption in `!!omap` resolution: a large omap sequence triggers a linear duplicate-key scan per element, blocking the event loop (DoS). dev-only, via vite-plugin-svgr -> @svgr/core -> cosmiconfig.

Resolves SECURE-4465 / CLNP-8804.